### PR TITLE
use tput instead of clear

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -867,9 +867,11 @@ NormalPADD() {
     GetSummaryInformation ${PADDsize}
     GetSystemInformation ${PADDsize}
 
-    # Sleep for 5 seconds, then clear the screen
+    # Sleep for 5 seconds
     sleep 5
-    clear
+    
+    # use tput cup to reposition cursor at top of screen to avoid clear/redraw flicker
+    tput cup 0 0
   done
 }
 


### PR DESCRIPTION
Use tput cup 0 0 to reposition cursor to 0,0 avoiding the flicker caused by clear and print not being part of the same buffer