### PR TITLE
Update date checking fix

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -356,11 +356,12 @@ GetVersionInformation() {
     # the file exits, use it
     source piHoleVersion
 
+    # Today is...
+    today=$(date +%Y%m%d)
+    
     # was the last check today?
     if [ "${today}" != "${lastCheck}" ]; then # no, it wasn't today
-      # Today is...
-      today=$(date +%Y%m%d)
-
+      
       # what are the latest available versions?
       # TODO: update if necessary if added to pihole
       piholeVersionLatest=$(pihole -v -p -l | awk '{print $5}' | tr -d "[:alpha:]")
@@ -581,7 +582,8 @@ PrintPiholeStats() {
   # else we're not
   else
     echo "${boldText}STATS ======================================================${resetText}"
-    printf " %-10s%-49s\n" "Blocking:" "${domains_being_blocked} domains"
+    printf " %-10s%-49s\n" "Blocking:" "${domains_being_blocked} dom# Today is...
+      today=$(date +%Y%m%d)ains"
     printf " %-10s[%-40s] %-5s\n" "Pi-holed:" "${adsBlockedBar}" "${ads_percentage_today}%"
     printf " %-10s%-49s\n" "Pi-holed:" "${ads_blocked_today} out of ${dns_queries_today} queries"
     printf " %-10s%-39s\n" "Latest:" "${latestBlocked}"


### PR DESCRIPTION
Correct the behavior of the version checking function to update today's date before comparing it to the date of last check. 

This fixes the existing behavior of: if the date the script is started is the same as the date of last check (e.g. you performed a quick restart of your pihole but a check happened earlier that day), then the GetVersionInformation function would never reacquire today's date nor actually check version information. This will also indirectly fix the issue of PADD returning out-of-date version messages indefinitely (unless the script is run again) if run on startup before the pihole DNS is fully initiated, since version checking will now actually happen regularly ;)