### PR TITLE
Fix for Temp On Virtual Machines

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -173,7 +173,11 @@ GetSystemInformation() {
   fi
 
   # CPU temperature
-  cpu=$(</sys/class/thermal/thermal_zone0/temp)
+  if [ -f /sys/class/thermal/thermal_zone0/temp ]; then
+    cpu=$(</sys/class/thermal/thermal_zone0/temp)
+  else
+    cpu=0
+  fi
 
   # Convert CPU temperature to correct unit
   if [ "${TEMPERATUREUNIT}" == "F" ]; then


### PR DESCRIPTION
Virtual machines running PADD don't have a thermal counter for the temp, so the script fails several checks and clutters the screen.  This defaults it to '0' for temperature if not found.