### PR TITLE
Eliminate flashing by repainting rather than replacing

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -572,7 +572,7 @@ CleanEcho() {
 
 # wrapper - printf with a clear eol first
 CleanPrintf() {
-  tput el
+#  tput el
   printf "$@"
 }
 
@@ -583,11 +583,14 @@ PrintLogo() {
   elif [ "$1" = "nano" ]; then
     CleanEcho "n${padd_text} ${mini_status_}"
   elif [ "$1" = "micro" ]; then
-    CleanEcho "µ${padd_text}     ${mini_status_}\\n"
+    CleanEcho "µ${padd_text}     ${mini_status_}"
+    CleanEcho ""
   elif [ "$1" = "mini" ]; then
-    CleanEcho "${padd_text}${dim_text}mini${reset_text}  ${mini_status_}\\n"
+    CleanEcho "${padd_text}${dim_text}mini${reset_text}  ${mini_status_}"
+    CleanEcho ""
   elif [ "$1" = "slim" ]; then
-    CleanEcho "${padd_text}${dim_text}slim${reset_text}   ${full_status_}\\n"
+    CleanEcho "${padd_text}${dim_text}slim${reset_text}   ${full_status_}"
+    CleanEcho ""
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${padd_logo_1}"
     CleanEcho "${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}"

--- a/padd.sh
+++ b/padd.sh
@@ -590,17 +590,18 @@ PrintLogo() {
     CleanEcho ""
   elif [ "$1" = "slim" ]; then
     CleanEcho "${padd_text}${dim_text}slim${reset_text}   ${full_status_}"
-    CleanEcho ""
+    CleanEcho ""\
+  # For the next two, use printf to make sure spaces aren't collapsed
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    CleanEcho "${padd_logo_1}"
-    CleanEcho "${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}"
-    CleanEcho "${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}"
+    CleanPrintf "${padd_logo_1}\e[0K\\n"
+    CleanPrintf "${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}\e[0K\\n"
+    CleanPrintf "${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}\e[0K\\n"
     CleanEcho ""
   # normal or not defined
   else
-    CleanEcho "${padd_logo_retro_1}"
-    CleanEcho "${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}"
-    CleanEcho "${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}"
+    CleanPrintf "${padd_logo_retro_1}\e[0K\\n"
+    CleanPrintf "${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}\e[0K\\n"
+    CleanPrintf "${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}\e[0K\\n"
 
     CleanEcho ""
   fi

--- a/padd.sh
+++ b/padd.sh
@@ -565,51 +565,56 @@ GetVersionInformation() {
 # terminfo clr_eol (clears to end of line
 ceol=$(tput el)
 
+CleanEcho() {
+  tput el
+  echo -e "$1"
+}
+
 PrintLogo() {
   # Screen size checks
   if [ "$1" = "pico" ]; then
-    echo -e "${ceol}p${padd_text} ${pico_status}"
+    CleanEcho("p${padd_text} ${pico_status}")
   elif [ "$1" = "nano" ]; then
-    echo -e "${ceol}n${padd_text} ${mini_status_}"
+    CleanEcho("n${padd_text} ${mini_status_}")
   elif [ "$1" = "micro" ]; then
-    echo -e "${ceol}µ${padd_text}     ${mini_status_}\\n"
+    CleanEcho("µ${padd_text}     ${mini_status_}\\n")
   elif [ "$1" = "mini" ]; then
-    echo -e "${ceol}${padd_text}${dim_text}mini${reset_text}  ${mini_status_}\\n"
+    CleanEcho("${padd_text}${dim_text}mini${reset_text}  ${mini_status_}\\n")
   elif [ "$1" = "slim" ]; then
-    echo -e "${ceol}${padd_text}${dim_text}slim${reset_text}   ${full_status_}\\n"
+    CleanEcho("${padd_text}${dim_text}slim${reset_text}   ${full_status_}\\n")
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo -e "${ceol}${padd_logo_1}"
-    echo -e "${ceol}${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}"
-    echo -e "${ceol}${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}"
-    echo -e "${ceol}"
+    CleanEcho("${padd_logo_1}")
+    CleanEcho("${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}")
+    CleanEcho("${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}")
+    CleanEcho("")
   # normal or not defined
   else
-    echo -e "${ceol}${padd_logo_retro_1}"
-    echo -e "${ceol}${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}"
-    echo -e "${ceol}${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}"
+    CleanEcho("${padd_logo_retro_1}")
+    CleanEcho("${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}")
+    CleanEcho("${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}")
 
-    echo -e "${ceol}"
+    CleanEcho("")
   fi
 }
 
 PrintNetworkInformation() {
   if [ "$1" = "pico" ]; then
-    echo -e "${ceol}${bold_text}NETWORK ============${reset_text}"
-    echo -e "${ceol} Hst: ${pi_hostname}"
-    echo -e "${ceol} IP:  ${pi_ip_address}"
-    echo -e "${ceol} DHCP ${dhcp_check_box} IPv6 ${dhcp_ipv6_check_box}"
+    CleanEcho("${bold_text}NETWORK ============${reset_text}")
+    CleanEcho(" Hst: ${pi_hostname}")
+    CleanEcho(" IP:  ${pi_ip_address}")
+    CleanEcho(" DHCP ${dhcp_check_box} IPv6 ${dhcp_ipv6_check_box}")
   elif [ "$1" = "nano" ]; then
-    echo -e "${ceol}${bold_text}NETWORK ================${reset_text}"
-    echo -e "${ceol} Host: ${pi_hostname}"
-    echo -e "${ceol} IPv4: ${IPV4_ADDRESS}"
-    echo -e "${ceol} DHCP: ${dhcp_check_box}    IPv6: ${dhcp_ipv6_check_box}"
+    CleanEcho("${bold_text}NETWORK ================${reset_text}")
+    CleanEcho(" Host: ${pi_hostname}")
+    CleanEcho(" IPv4: ${IPV4_ADDRESS}")
+    CleanEcho(" DHCP: ${dhcp_check_box}    IPv6: ${dhcp_ipv6_check_box}")
   elif [ "$1" = "micro" ]; then
-    echo -e "${ceol}${bold_text}NETWORK ======================${reset_text}"
-    echo -e "${ceol} Host:    ${full_hostname}"
-    echo -e "${ceol} IPv4:    ${IPV4_ADDRESS}"
-    echo -e "${ceol} DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
+    CleanEcho("${bold_text}NETWORK ======================${reset_text}")
+    CleanEcho(" Host:    ${full_hostname}")
+    CleanEcho(" IPv4:    ${IPV4_ADDRESS}")
+    CleanEcho(" DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}")
   elif [ "$1" = "mini" ]; then
-    echo -e "${ceol}${bold_text}NETWORK ================================${reset_text}"
+    CleanEcho("${bold_text}NETWORK ================================${reset_text}")
     tput el
     printf " %-9s%-19s\\n" "Host:" "${full_hostname}"
     tput el
@@ -622,7 +627,7 @@ PrintNetworkInformation() {
       printf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo -e "${ceol}${bold_text}NETWORK ====================================================${reset_text}"
+    CleanEcho("${bold_text}NETWORK ====================================================${reset_text}")
     tput el
     printf " %-10s%-19s %-10s%-19s\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
     tput el
@@ -637,18 +642,18 @@ PrintNetworkInformation() {
       printf "%s\\n" "${dhcp_info}"
     fi
   else
-    echo -e "${ceol}${bold_text}NETWORK ========================================================================${reset_text}"
+    CleanEcho("${bold_text}NETWORK ========================================================================${reset_text}")
     tput el
     printf " %-10s%-19s\\n" "Hostname:" "${full_hostname}"
     tput el
     printf " %-10s%-19s %-10s%-29s\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
-    echo "DNS ============================================================================"
+    CleanEcho("DNS ============================================================================")
     tput el
     printf " %-10s%-39s\\n" "Servers:" "${dns_information}"
     tput el
     printf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
 
-    echo -e "${ceol}DHCP ==========================================================================="
+    CleanEcho("DHCP ===========================================================================")
     tput el
     printf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
     tput el
@@ -661,17 +666,17 @@ PrintPiholeInformation() {
   if [ "$1" = "pico" ]; then
     :
   elif [ "$1" = "nano" ]; then
-    echo -e "${ceol}${bold_text}PI-HOLE ================${reset_text}"
-    echo -e "${ceol} Up:  ${pihole_check_box}      FTL: ${ftl_check_box}"
+    CleanEcho("${bold_text}PI-HOLE ================${reset_text}")
+    CleanEcho(" Up:  ${pihole_check_box}      FTL: ${ftl_check_box}")
   elif [ "$1" = "micro" ]; then
-    echo -e "${ceol}${bold_text}PI-HOLE ======================${reset_text}"
-    echo -e "${ceol} Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}"
+    CleanEcho("${bold_text}PI-HOLE ======================${reset_text}")
+    CleanEcho(" Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}")
   elif [ "$1" = "mini" ]; then
-    echo -e "${ceol}${bold_text}PI-HOLE ================================${reset_text}"
+    CleanEcho("${bold_text}PI-HOLE ================================${reset_text}")
     tput el
     printf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo "${ceol}${bold_text}PI-HOLE ====================================================${reset_text}"
+    CleanEcho("${bold_text}PI-HOLE ====================================================${reset_text}")
     tput el
     printf " %-10s${pihole_heatmap}%-19s${reset_text} %-10s${ftl_heatmap}%-19s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   else
@@ -682,19 +687,19 @@ PrintPiholeInformation() {
 PrintPiholeStats() {
   # are we on a tiny screen?
   if [ "$1" = "pico" ]; then
-    echo -e "${ceol}${bold_text}PI-HOLE ============${reset_text}"
-    echo -e "${ceol} [${ads_blocked_bar}] ${ads_percentage_today}%"
-    echo -e "${ceol} ${ads_blocked_today} / ${dns_queries_today}"
+    CleanEcho("${bold_text}PI-HOLE ============${reset_text}")
+    CleanEcho(" [${ads_blocked_bar}] ${ads_percentage_today}%")
+    CleanEcho(" ${ads_blocked_today} / ${dns_queries_today}")
   elif [ "$1" = "nano" ]; then
-    echo -e "${ceol} Blk: [${ads_blocked_bar}] ${ads_percentage_today}%"
-    echo -e "${ceol} Blk: ${ads_blocked_today} / ${dns_queries_today}"
+    CleanEcho(" Blk: [${ads_blocked_bar}] ${ads_percentage_today}%")
+    CleanEcho(" Blk: ${ads_blocked_today} / ${dns_queries_today}")
   elif [ "$1" = "micro" ]; then
-    echo -e "${ceol}${bold_text}STATS ========================${reset_text}"
-    echo -e "${ceol} Blckng:  ${domains_being_blocked} domains"
-    echo -e "${ceol} Piholed: [${ads_blocked_bar}] ${ads_percentage_today}%"
-    echo -e "${ceol} Piholed: ${ads_blocked_today} / ${dns_queries_today}"
+    CleanEcho("${bold_text}STATS ========================${reset_text}")
+    CleanEcho(" Blckng:  ${domains_being_blocked} domains")
+    CleanEcho(" Piholed: [${ads_blocked_bar}] ${ads_percentage_today}%")
+    CleanEcho(" Piholed: ${ads_blocked_today} / ${dns_queries_today}")
   elif [ "$1" = "mini" ]; then
-    echo -e "${ceol}${bold_text}STATS ==================================${reset_text}"
+    CleanEcho("${bold_text}STATS ==================================${reset_text}")
     tput el
     printf " %-9s%-29s\\n" "Blckng:" "${domains_being_blocked} domains"
     tput el
@@ -708,7 +713,7 @@ PrintPiholeStats() {
       printf " %-9s%-29s\\n" "Top Ad:" "${top_blocked}"
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo "${ceol}${bold_text}STATS ======================================================${reset_text}"
+    CleanEcho("${bold_text}STATS ======================================================${reset_text}")
     tput el
     printf " %-10s%-49s\\n" "Blocking:" "${domains_being_blocked} domains"
     tput el
@@ -726,7 +731,7 @@ PrintPiholeStats() {
       printf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
     fi
   else
-    echo  -e "${ceol}${bold_text}STATS ==========================================================================${reset_text}"
+    CleanEcho("${bold_text}STATS ==========================================================================${reset_text}")
     tput el
     printf " %-10s%-19s %-10s[%-40s] %-5s\\n" "Blocking:" "${domains_being_blocked} domains" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
     tput el
@@ -739,7 +744,7 @@ PrintPiholeStats() {
     printf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
     tput el
     printf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
-    echo -e "${ceol}FTL ============================================================================"
+    CleanEcho("FTL ============================================================================")
     tput el
     printf " %-10s%-9s %-10s%-9s %-10s%-9s\\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
     tput el
@@ -749,26 +754,26 @@ PrintPiholeStats() {
 
 PrintSystemInformation() {
   if [ "$1" = "pico" ]; then
-    echo -e "${ceol}${bold_text}CPU ================${reset_text}"
+    CleanEcho("${bold_text}CPU ================${reset_text}")
     echo -ne "${ceol} [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
   elif [ "$1" = "nano" ]; then
-    echo -e "${ceol}${ceol}${bold_text}SYSTEM =================${reset_text}"
-    echo -e  "${ceol} Up:  ${system_uptime}"
+    CleanEcho("${ceol}${bold_text}SYSTEM =================${reset_text}")
+    CleanEcho(" Up:  ${system_uptime}")
     echo -ne  "${ceol} CPU: [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
   elif [ "$1" = "micro" ]; then
-    echo -e "${ceol}${bold_text}SYSTEM =======================${reset_text}"
-    echo -e  "${ceol} Uptime:  ${system_uptime}"
-    echo -e  "${ceol} Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
+    CleanEcho("${bold_text}SYSTEM =======================${reset_text}")
+    CleanEcho(" Uptime:  ${system_uptime}")
+    CleanEcho(" Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%")
     echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   elif [ "$1" = "mini" ]; then
-    echo -e "${ceol}${bold_text}SYSTEM =================================${reset_text}"
+    CleanEcho("${bold_text}SYSTEM =================================${reset_text}")
     tput el
     printf " %-9s%-29s\\n" "Uptime:" "${system_uptime}"
-    echo -e  "${ceol} Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
+    CleanEcho(" Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%")
     echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   # else we're not
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo -e "${ceol}${bold_text}SYSTEM =====================================================${reset_text}"
+    CleanEcho("${bold_text}SYSTEM =====================================================${reset_text}")
     # Uptime
     tput el
     printf " %-10s%-39s\\n" "Uptime:" "${system_uptime}"

--- a/padd.sh
+++ b/padd.sh
@@ -565,7 +565,7 @@ GetVersionInformation() {
 # terminfo clr_eol (clears to end of line to erase artifacts after resizing smaller)
 ceol=$(tput el)
 
-# wrapper - echo with a clear eol first
+# wrapper - echo with a clear eol afterwards to wipe any artifacts remaining from last print
 CleanEcho() {
   echo -e $1 "${ceol}"
 }
@@ -1069,7 +1069,7 @@ NormalPADD() {
     PrintNetworkInformation ${padd_size}
     PrintSystemInformation ${padd_size}
     
-    # clear to end of screen
+    # Clear to end of screen (below the drawn dashboard)
     tput ed
 
     pico_status=${pico_status_ok}

--- a/padd.sh
+++ b/padd.sh
@@ -565,9 +565,9 @@ GetVersionInformation() {
 # terminfo clr_eol (clears to end of line
 ceol=$(tput el)
 
-CleanEcho  {
+CleanEcho() {
   tput el
-  echo -e "$1"
+  echo -e $1
 }
 
 PrintLogo() {

--- a/padd.sh
+++ b/padd.sh
@@ -565,10 +565,9 @@ GetVersionInformation() {
 # terminfo clr_eol (clears to end of line to erase artifacts after resizing smaller)
 ceol=$(tput el)
 
-# wrapper - echoe with a clear eol first
+# wrapper - echo with a clear eol first
 CleanEcho() {
-  tput el
-  echo -e $1
+  echo -e $1 "${ceol}"
 }
 
 # wrapper - printf with a clear eol first

--- a/padd.sh
+++ b/padd.sh
@@ -610,8 +610,11 @@ PrintNetworkInformation() {
     echo -e "${ceol} DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
   elif [ "$1" = "mini" ]; then
     echo "${bold_text}NETWORK ================================${reset_text}"
+    ceol
     printf " %-9s%-19s\\n" "Host:" "${full_hostname}"
+    ceol
     printf " %-9s%-19s\\n" "IPv4:" "${IPV4_ADDRESS}"
+    ceol
     printf " %-9s%-10s\\n" "DNS:" "${dns_information}"
 
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
@@ -619,8 +622,11 @@ PrintNetworkInformation() {
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     echo "${bold_text}NETWORK ====================================================${reset_text}"
+    ceol
     printf " %-10s%-19s %-10s%-19s\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
+    ceol
     printf " %-10s%-19s\\n" "IPv6:" "${IPV6_ADDRESS}"
+    ceol
     printf " %-10s%-19s %-10s%-19s\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
@@ -629,14 +635,20 @@ PrintNetworkInformation() {
     fi
   else
     echo "${bold_text}NETWORK ========================================================================${reset_text}"
+    ceol
     printf " %-10s%-19s\\n" "Hostname:" "${full_hostname}"
+    ceol
     printf " %-10s%-19s %-10s%-29s\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
     echo "DNS ============================================================================"
+    ceol
     printf " %-10s%-39s\\n" "Servers:" "${dns_information}"
+    ceol
     printf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
 
     echo "DHCP ==========================================================================="
+    ceol
     printf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
+    ceol
     printf "%s\\n" "${dhcp_info}"
   fi
 }

--- a/padd.sh
+++ b/padd.sh
@@ -581,35 +581,35 @@ PrintLogo() {
     echo -e "${ceol}${padd_logo_1}"
     echo -e "${ceol}${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}"
     echo -e "${ceol}${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}"
-    echo ""
+    echo -e "${ceol}"
   # normal or not defined
   else
     echo -e "${ceol}${padd_logo_retro_1}"
     echo -e "${ceol}${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}"
     echo -e "${ceol}${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}"
 
-    echo ""
+    echo -e "${ceol}"
   fi
 }
 
 PrintNetworkInformation() {
   if [ "$1" = "pico" ]; then
-    echo "${bold_text}NETWORK ============${reset_text}"
+    echo -e "${ceol}${bold_text}NETWORK ============${reset_text}"
     echo -e "${ceol} Hst: ${pi_hostname}"
     echo -e "${ceol} IP:  ${pi_ip_address}"
     echo -e "${ceol} DHCP ${dhcp_check_box} IPv6 ${dhcp_ipv6_check_box}"
   elif [ "$1" = "nano" ]; then
-    echo "${bold_text}NETWORK ================${reset_text}"
+    echo -e "${ceol}${bold_text}NETWORK ================${reset_text}"
     echo -e "${ceol} Host: ${pi_hostname}"
     echo -e "${ceol} IPv4: ${IPV4_ADDRESS}"
     echo -e "${ceol} DHCP: ${dhcp_check_box}    IPv6: ${dhcp_ipv6_check_box}"
   elif [ "$1" = "micro" ]; then
-    echo "${bold_text}NETWORK ======================${reset_text}"
+    echo -e "${ceol}${bold_text}NETWORK ======================${reset_text}"
     echo -e "${ceol} Host:    ${full_hostname}"
     echo -e "${ceol} IPv4:    ${IPV4_ADDRESS}"
     echo -e "${ceol} DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
   elif [ "$1" = "mini" ]; then
-    echo "${bold_text}NETWORK ================================${reset_text}"
+    echo -e "${ceol}${bold_text}NETWORK ================================${reset_text}"
     tput el
     printf " %-9s%-19s\\n" "Host:" "${full_hostname}"
     tput el
@@ -622,7 +622,7 @@ PrintNetworkInformation() {
       printf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo "${bold_text}NETWORK ====================================================${reset_text}"
+    echo -e "${ceol}${bold_text}NETWORK ====================================================${reset_text}"
     tput el
     printf " %-10s%-19s %-10s%-19s\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
     tput el
@@ -637,7 +637,7 @@ PrintNetworkInformation() {
       printf "%s\\n" "${dhcp_info}"
     fi
   else
-    echo "${bold_text}NETWORK ========================================================================${reset_text}"
+    echo -e "${ceol}${bold_text}NETWORK ========================================================================${reset_text}"
     tput el
     printf " %-10s%-19s\\n" "Hostname:" "${full_hostname}"
     tput el
@@ -648,7 +648,7 @@ PrintNetworkInformation() {
     tput el
     printf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
 
-    echo "DHCP ==========================================================================="
+    echo -e "${ceol}DHCP ==========================================================================="
     tput el
     printf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
     tput el
@@ -661,16 +661,18 @@ PrintPiholeInformation() {
   if [ "$1" = "pico" ]; then
     :
   elif [ "$1" = "nano" ]; then
-    echo "${bold_text}PI-HOLE ================${reset_text}"
+    echo -e "${ceol}${bold_text}PI-HOLE ================${reset_text}"
     echo -e "${ceol} Up:  ${pihole_check_box}      FTL: ${ftl_check_box}"
   elif [ "$1" = "micro" ]; then
-    echo "${bold_text}PI-HOLE ======================${reset_text}"
+    echo -e "${ceol}${bold_text}PI-HOLE ======================${reset_text}"
     echo -e "${ceol} Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}"
   elif [ "$1" = "mini" ]; then
-    echo "${bold_text}PI-HOLE ================================${reset_text}"
+    echo -e "${ceol}${bold_text}PI-HOLE ================================${reset_text}"
+    tput el
     printf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo "${bold_text}PI-HOLE ====================================================${reset_text}"
+    echo "${ceol}${bold_text}PI-HOLE ====================================================${reset_text}"
+    tput el
     printf " %-10s${pihole_heatmap}%-19s${reset_text} %-10s${ftl_heatmap}%-19s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   else
     return
@@ -680,87 +682,114 @@ PrintPiholeInformation() {
 PrintPiholeStats() {
   # are we on a tiny screen?
   if [ "$1" = "pico" ]; then
-    echo "${bold_text}PI-HOLE ============${reset_text}"
+    echo -e "${ceol}${bold_text}PI-HOLE ============${reset_text}"
     echo -e "${ceol} [${ads_blocked_bar}] ${ads_percentage_today}%"
     echo -e "${ceol} ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "nano" ]; then
     echo -e "${ceol} Blk: [${ads_blocked_bar}] ${ads_percentage_today}%"
     echo -e "${ceol} Blk: ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "micro" ]; then
-    echo "${bold_text}STATS ========================${reset_text}"
+    echo -e "${ceol}${bold_text}STATS ========================${reset_text}"
     echo -e "${ceol} Blckng:  ${domains_being_blocked} domains"
     echo -e "${ceol} Piholed: [${ads_blocked_bar}] ${ads_percentage_today}%"
     echo -e "${ceol} Piholed: ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "mini" ]; then
-    echo "${bold_text}STATS ==================================${reset_text}"
+    echo -e "${ceol}${bold_text}STATS ==================================${reset_text}"
+    tput el
     printf " %-9s%-29s\\n" "Blckng:" "${domains_being_blocked} domains"
+    tput el
     printf " %-9s[%-20s] %-5s\\n" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    tput el
     printf " %-9s%-29s\\n" "Piholed:" "${ads_blocked_today} out of ${dns_queries_today}"
+    tput el
     printf " %-9s%-29s\\n" "Latest:" "${latest_blocked}"
     if [[ "${DHCP_ACTIVE}" != "true" ]]; then
+      tput el
       printf " %-9s%-29s\\n" "Top Ad:" "${top_blocked}"
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo "${bold_text}STATS ======================================================${reset_text}"
+    echo "${ceol}${bold_text}STATS ======================================================${reset_text}"
+    tput el
     printf " %-10s%-49s\\n" "Blocking:" "${domains_being_blocked} domains"
+    tput el
     printf " %-10s[%-40s] %-5s\\n" "Pi-holed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    tput el
     printf " %-10s%-49s\\n" "Pi-holed:" "${ads_blocked_today} out of ${dns_queries_today} queries"
+    tput el
     printf " %-10s%-39s\\n" "Latest:" "${latest_blocked}"
+    tput el
     printf " %-10s%-39s\\n" "Top Ad:" "${top_blocked}"
     if [[ "${DHCP_ACTIVE}" != "true" ]]; then
+      tput el
       printf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
+      tput el
       printf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
     fi
   else
-    echo "${bold_text}STATS ==========================================================================${reset_text}"
+    echo  -e "${ceol}${bold_text}STATS ==========================================================================${reset_text}"
+    tput el
     printf " %-10s%-19s %-10s[%-40s] %-5s\\n" "Blocking:" "${domains_being_blocked} domains" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    tput el
     printf " %-10s%-30s%-29s\\n" "Clients:" "${clients}" " ${ads_blocked_today} out of ${dns_queries_today} queries"
+    tput el
     printf " %-10s%-39s\\n" "Latest:" "${latest_blocked}"
+    tput el
     printf " %-10s%-39s\\n" "Top Ad:" "${top_blocked}"
+    tput el
     printf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
+    tput el
     printf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
-    echo "FTL ============================================================================"
+    echo -e "${ceol}FTL ============================================================================"
+    tput el
     printf " %-10s%-9s %-10s%-9s %-10s%-9s\\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
+    tput el
     printf " %-10s%-69s\\n" "DNSCache:" "${cache_inserts} insertions, ${cache_deletes} deletions, ${cache_size} total entries"
   fi
 }
 
 PrintSystemInformation() {
   if [ "$1" = "pico" ]; then
-    echo "${bold_text}CPU ================${reset_text}"
-    echo -ne " [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
+    echo -e "${ceol}${bold_text}CPU ================${reset_text}"
+    echo -ne "${ceol} [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
   elif [ "$1" = "nano" ]; then
-    echo "${bold_text}SYSTEM =================${reset_text}"
-    echo -e  " Up:  ${system_uptime}"
-    echo -ne  " CPU: [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
+    echo -e "${ceol}${ceol}${bold_text}SYSTEM =================${reset_text}"
+    echo -e  "${ceol} Up:  ${system_uptime}"
+    echo -ne  "${ceol} CPU: [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
   elif [ "$1" = "micro" ]; then
-    echo "${bold_text}SYSTEM =======================${reset_text}"
-    echo -e  " Uptime:  ${system_uptime}"
-    echo -e  " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
-    echo -ne " Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
+    echo -e "${ceol}${bold_text}SYSTEM =======================${reset_text}"
+    echo -e  "${ceol} Uptime:  ${system_uptime}"
+    echo -e  "${ceol} Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
+    echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   elif [ "$1" = "mini" ]; then
-    echo "${bold_text}SYSTEM =================================${reset_text}"
+    echo -e "${ceol}${bold_text}SYSTEM =================================${reset_text}"
+    tput el
     printf " %-9s%-29s\\n" "Uptime:" "${system_uptime}"
-    echo -e  " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
-    echo -ne " Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
+    echo -e  "${ceol} Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
+    echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   # else we're not
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo "${bold_text}SYSTEM =====================================================${reset_text}"
+    echo -e "${ceol}${bold_text}SYSTEM =====================================================${reset_text}"
     # Uptime
+    tput el
     printf " %-10s%-39s\\n" "Uptime:" "${system_uptime}"
 
     # Temp and Loads
+    tput el
     printf " %-10s${temp_heatmap}%-20s${reset_text}" "CPU Temp:" "${temperature}"
+    tput el
     printf " %-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}\\n" "CPU Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}"
 
     # Memory and CPU bar
+    tput el
     printf " %-10s[${memory_heatmap}%-10s${reset_text}] %-6s %-10s[${cpu_load_1_heatmap}%-10s${reset_text}] %-5s" "Memory:" "${memory_bar}" "${memory_percent}%" "CPU Load:" "${cpu_bar}" "${cpu_percent}%"
   else
-    echo "${bold_text}SYSTEM =========================================================================${reset_text}"
+    echo "${ceol}${bold_text}SYSTEM =========================================================================${reset_text}"
     # Uptime and memory
+    tput el
     printf " %-10s%-39s %-10s[${memory_heatmap}%-10s${reset_text}] %-6s\\n" "Uptime:" "${system_uptime}" "Memory:" "${memory_bar}" "${memory_percent}%"
 
     # CPU temp, load, percentage
+    tput el
     printf " %-10s${temp_heatmap}%-10s${reset_text} %-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-7s${reset_text} %-10s[${memory_heatmap}%-10s${reset_text}] %-6s" "CPU Temp:" "${temperature}" "CPU Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}" "CPU Load:" "${cpu_bar}" "${cpu_percent}%"
   fi
 }

--- a/padd.sh
+++ b/padd.sh
@@ -624,34 +624,34 @@ PrintNetworkInformation() {
     CleanEcho " DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}NETWORK ================================${reset_text}"
-    CleanPrintf " %-9s%-19s\\n" "Host:" "${full_hostname}"
-    CleanPrintf " %-9s%-19s\\n" "IPv4:" "${IPV4_ADDRESS}"
-    CleanPrintf " %-9s%-10s\\n" "DNS:" "${dns_information}"
+    CleanPrintf " %-9s%-19s\e[0K\\n" "Host:" "${full_hostname}"
+    CleanPrintf " %-9s%-19s\e[0K\\n" "IPv4:" "${IPV4_ADDRESS}"
+    CleanPrintf " %-9s%-10s\e[0K\\n" "DNS:" "${dns_information}"
 
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
-      CleanPrintf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
+      CleanPrintf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\e[0K\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}NETWORK ====================================================${reset_text}"
-    CleanPrintf " %-10s%-19s %-10s%-19s\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
-    CleanPrintf " %-10s%-19s\\n" "IPv6:" "${IPV6_ADDRESS}"
-    CleanPrintf " %-10s%-19s %-10s%-19s\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
+    CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
+    CleanPrintf " %-10s%-19s\e[0K\\n" "IPv6:" "${IPV6_ADDRESS}"
+    CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
-      CleanPrintf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-19s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
-      CleanPrintf "%s\\n" "${dhcp_info}"
+      CleanPrintf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-19s${reset_text}\e[0K\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
+      CleanPrintf "%s\e[0K\\n" "${dhcp_info}"
     fi
   else
     CleanEcho "${bold_text}NETWORK ========================================================================${reset_text}"
-    CleanPrintf " %-10s%-19s\\n" "Hostname:" "${full_hostname}"
-    CleanPrintf " %-10s%-19s %-10s%-29s\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
+    CleanPrintf " %-10s%-19s\e[0K\\n" "Hostname:" "${full_hostname}"
+    CleanPrintf " %-10s%-19s %-10s%-29\e[0Ks\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
     CleanEcho "DNS ============================================================================"
-    CleanPrintf " %-10s%-39s\\n" "Servers:" "${dns_information}"
-    CleanPrintf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Servers:" "${dns_information}"
+    CleanPrintf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\e[0K\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
 
     CleanEcho "DHCP ==========================================================================="
-    CleanPrintf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
-    CleanPrintf "%s\\n" "${dhcp_info}"
+    CleanPrintf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\e[0K\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
+    CleanPrintf "%s\e[0K\\n" "${dhcp_info}"
   fi
 }
 
@@ -667,10 +667,10 @@ PrintPiholeInformation() {
     CleanEcho " Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}PI-HOLE ================================${reset_text}"
-    CleanPrintf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
+    CleanPrintf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\e[0K\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}PI-HOLE ====================================================${reset_text}"
-    CleanPrintf " %-10s${pihole_heatmap}%-19s${reset_text} %-10s${ftl_heatmap}%-19s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
+    CleanPrintf " %-10s${pihole_heatmap}%-19s${reset_text} %-10s${ftl_heatmap}%-19s${reset_text}\e[0K\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   else
     return
   fi
@@ -692,35 +692,35 @@ PrintPiholeStats() {
     CleanEcho " Piholed: ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}STATS ==================================${reset_text}"
-    CleanPrintf " %-9s%-29s\\n" "Blckng:" "${domains_being_blocked} domains"
-    CleanPrintf " %-9s[%-20s] %-5s\\n" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
-    CleanPrintf " %-9s%-29s\\n" "Piholed:" "${ads_blocked_today} out of ${dns_queries_today}"
-    CleanPrintf " %-9s%-29s\\n" "Latest:" "${latest_blocked}"
+    CleanPrintf " %-9s%-29s\e[0K\\n" "Blckng:" "${domains_being_blocked} domains"
+    CleanPrintf " %-9s[%-20s] %-5s\e[0K\\n" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    CleanPrintf " %-9s%-29s\e[0K\\n" "Piholed:" "${ads_blocked_today} out of ${dns_queries_today}"
+    CleanPrintf " %-9s%-29s\e[0K\\n" "Latest:" "${latest_blocked}"
     if [[ "${DHCP_ACTIVE}" != "true" ]]; then
       CleanPrintf " %-9s%-29s\\n" "Top Ad:" "${top_blocked}"
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}STATS ======================================================${reset_text}"
-    CleanPrintf " %-10s%-49s\\n" "Blocking:" "${domains_being_blocked} domains"
-    CleanPrintf " %-10s[%-40s] %-5s\\n" "Pi-holed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
-    CleanPrintf " %-10s%-49s\\n" "Pi-holed:" "${ads_blocked_today} out of ${dns_queries_today} queries"
-    CleanPrintf " %-10s%-39s\\n" "Latest:" "${latest_blocked}"
-    CleanPrintf " %-10s%-39s\\n" "Top Ad:" "${top_blocked}"
+    CleanPrintf " %-10s%-49s\e[0K\\n" "Blocking:" "${domains_being_blocked} domains"
+    CleanPrintf " %-10s[%-40s] %-5s\e[0K\\n" "Pi-holed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    CleanPrintf " %-10s%-49s\e[0K\\n" "Pi-holed:" "${ads_blocked_today} out of ${dns_queries_today} queries"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Latest:" "${latest_blocked}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Top Ad:" "${top_blocked}"
     if [[ "${DHCP_ACTIVE}" != "true" ]]; then
-      CleanPrintf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
-      CleanPrintf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
+      CleanPrintf " %-10s%-39s\e[0K\\n" "Top Dmn:" "${top_domain}"
+      CleanPrintf " %-10s%-39s\e[0K\\n" "Top Clnt:" "${top_client}"
     fi
   else
     CleanEcho "${bold_text}STATS ==========================================================================${reset_text}"
-    CleanPrintf " %-10s%-19s %-10s[%-40s] %-5s\\n" "Blocking:" "${domains_being_blocked} domains" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
-    CleanPrintf " %-10s%-30s%-29s\\n" "Clients:" "${clients}" " ${ads_blocked_today} out of ${dns_queries_today} queries"
-    CleanPrintf " %-10s%-39s\\n" "Latest:" "${latest_blocked}"
-    CleanPrintf " %-10s%-39s\\n" "Top Ad:" "${top_blocked}"
-    CleanPrintf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
-    CleanPrintf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
+    CleanPrintf " %-10s%-19s %-10s[%-40s] %-5s\e[0K\\n" "Blocking:" "${domains_being_blocked} domains" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    CleanPrintf " %-10s%-30s%-29s\e[0K\\n" "Clients:" "${clients}" " ${ads_blocked_today} out of ${dns_queries_today} queries"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Latest:" "${latest_blocked}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Top Ad:" "${top_blocked}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Top Dmn:" "${top_domain}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Top Clnt:" "${top_client}"
     CleanEcho "FTL ============================================================================"
-    CleanPrintf " %-10s%-9s %-10s%-9s %-10s%-9s\\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
-    CleanPrintf " %-10s%-69s\\n" "DNSCache:" "${cache_inserts} insertions, ${cache_deletes} deletions, ${cache_size} total entries"
+    CleanPrintf " %-10s%-9s %-10s%-9s %-10s%-9s\e[0K\\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
+    CleanPrintf " %-10s%-69s\e[0K\\n" "DNSCache:" "${cache_inserts} insertions, ${cache_deletes} deletions, ${cache_size} total entries"
   fi
 }
 
@@ -746,11 +746,11 @@ PrintSystemInformation() {
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}SYSTEM =====================================================${reset_text}"
     # Uptime
-    CleanPrintf " %-10s%-39s\\n" "Uptime:" "${system_uptime}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Uptime:" "${system_uptime}"
 
     # Temp and Loads
     CleanPrintf " %-10s${temp_heatmap}%-20s${reset_text}" "CPU Temp:" "${temperature}"
-    CleanPrintf " %-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}\\n" "CPU Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}"
+    CleanPrintf " %-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}\e[0K\\n" "CPU Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}"
 
     # Memory and CPU bar
     CleanPrintf " %-10s[${memory_heatmap}%-10s${reset_text}] %-6s %-10s[${cpu_load_1_heatmap}%-10s${reset_text}] %-5s" "Memory:" "${memory_bar}" "${memory_percent}%" "CPU Load:" "${cpu_bar}" "${cpu_percent}%"

--- a/padd.sh
+++ b/padd.sh
@@ -562,28 +562,31 @@ GetVersionInformation() {
 
 ############################################# PRINTERS #############################################
 
+# terminfo clr_eol (clears to end of line
+ceol=$(tput el)
+
 PrintLogo() {
   # Screen size checks
   if [ "$1" = "pico" ]; then
-    echo -e "p${padd_text} ${pico_status}"
+    echo -e "${ceol}p${padd_text} ${pico_status}"
   elif [ "$1" = "nano" ]; then
-    echo -e "n${padd_text} ${mini_status_}"
+    echo -e "${ceol}n${padd_text} ${mini_status_}"
   elif [ "$1" = "micro" ]; then
-    echo -e "µ${padd_text}     ${mini_status_}\\n"
+    echo -e "${ceol}µ${padd_text}     ${mini_status_}\\n"
   elif [ "$1" = "mini" ]; then
-    echo -e "${padd_text}${dim_text}mini${reset_text}  ${mini_status_}\\n"
+    echo -e "${ceol}${padd_text}${dim_text}mini${reset_text}  ${mini_status_}\\n"
   elif [ "$1" = "slim" ]; then
-    echo -e "${padd_text}${dim_text}slim${reset_text}   ${full_status_}\\n"
+    echo -e "${ceol}${padd_text}${dim_text}slim${reset_text}   ${full_status_}\\n"
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    echo -e "${padd_logo_1}"
-    echo -e "${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}"
-    echo -e "${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}"
+    echo -e "${ceol}${padd_logo_1}"
+    echo -e "${ceol}${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}"
+    echo -e "${ceol}${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}"
     echo ""
   # normal or not defined
   else
-    echo -e "${padd_logo_retro_1}"
-    echo -e "${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}"
-    echo -e "${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}"
+    echo -e "${ceol}${padd_logo_retro_1}"
+    echo -e "${ceol}${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}"
+    echo -e "${ceol}${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}"
 
     echo ""
   fi
@@ -592,19 +595,19 @@ PrintLogo() {
 PrintNetworkInformation() {
   if [ "$1" = "pico" ]; then
     echo "${bold_text}NETWORK ============${reset_text}"
-    echo -e " Hst: ${pi_hostname}"
-    echo -e " IP:  ${pi_ip_address}"
-    echo -e " DHCP ${dhcp_check_box} IPv6 ${dhcp_ipv6_check_box}"
+    echo -e "${ceol} Hst: ${pi_hostname}"
+    echo -e "${ceol} IP:  ${pi_ip_address}"
+    echo -e "${ceol} DHCP ${dhcp_check_box} IPv6 ${dhcp_ipv6_check_box}"
   elif [ "$1" = "nano" ]; then
     echo "${bold_text}NETWORK ================${reset_text}"
-    echo -e " Host: ${pi_hostname}"
-    echo -e " IPv4: ${IPV4_ADDRESS}"
-    echo -e " DHCP: ${dhcp_check_box}    IPv6: ${dhcp_ipv6_check_box}"
+    echo -e "${ceol} Host: ${pi_hostname}"
+    echo -e "${ceol} IPv4: ${IPV4_ADDRESS}"
+    echo -e "${ceol} DHCP: ${dhcp_check_box}    IPv6: ${dhcp_ipv6_check_box}"
   elif [ "$1" = "micro" ]; then
     echo "${bold_text}NETWORK ======================${reset_text}"
-    echo -e " Host:    ${full_hostname}"
-    echo -e " IPv4:    ${IPV4_ADDRESS}"
-    echo -e " DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
+    echo -e "${ceol} Host:    ${full_hostname}"
+    echo -e "${ceol} IPv4:    ${IPV4_ADDRESS}"
+    echo -e "${ceol} DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
   elif [ "$1" = "mini" ]; then
     echo "${bold_text}NETWORK ================================${reset_text}"
     printf " %-9s%-19s\\n" "Host:" "${full_hostname}"
@@ -644,10 +647,10 @@ PrintPiholeInformation() {
     :
   elif [ "$1" = "nano" ]; then
     echo "${bold_text}PI-HOLE ================${reset_text}"
-    echo -e " Up:  ${pihole_check_box}      FTL: ${ftl_check_box}"
+    echo -e "${ceol} Up:  ${pihole_check_box}      FTL: ${ftl_check_box}"
   elif [ "$1" = "micro" ]; then
     echo "${bold_text}PI-HOLE ======================${reset_text}"
-    echo -e " Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}"
+    echo -e "${ceol} Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}"
   elif [ "$1" = "mini" ]; then
     echo "${bold_text}PI-HOLE ================================${reset_text}"
     printf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
@@ -663,16 +666,16 @@ PrintPiholeStats() {
   # are we on a tiny screen?
   if [ "$1" = "pico" ]; then
     echo "${bold_text}PI-HOLE ============${reset_text}"
-    echo -e " [${ads_blocked_bar}] ${ads_percentage_today}%"
-    echo -e " ${ads_blocked_today} / ${dns_queries_today}"
+    echo -e "${ceol} [${ads_blocked_bar}] ${ads_percentage_today}%"
+    echo -e "${ceol} ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "nano" ]; then
-    echo -e " Blk: [${ads_blocked_bar}] ${ads_percentage_today}%"
-    echo -e " Blk: ${ads_blocked_today} / ${dns_queries_today}"
+    echo -e "${ceol} Blk: [${ads_blocked_bar}] ${ads_percentage_today}%"
+    echo -e "${ceol} Blk: ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "micro" ]; then
     echo "${bold_text}STATS ========================${reset_text}"
-    echo -e " Blckng:  ${domains_being_blocked} domains"
-    echo -e " Piholed: [${ads_blocked_bar}] ${ads_percentage_today}%"
-    echo -e " Piholed: ${ads_blocked_today} / ${dns_queries_today}"
+    echo -e "${ceol} Blckng:  ${domains_being_blocked} domains"
+    echo -e "${ceol} Piholed: [${ads_blocked_bar}] ${ads_percentage_today}%"
+    echo -e "${ceol} Piholed: ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "mini" ]; then
     echo "${bold_text}STATS ==================================${reset_text}"
     printf " %-9s%-29s\\n" "Blckng:" "${domains_being_blocked} domains"
@@ -1041,6 +1044,9 @@ NormalPADD() {
     # Get Config variables
     . /etc/pihole/setupVars.conf
 
+    # Move the cursor to top left of console to redraw
+    tput cup 0 0
+
     # Output everything to the screen
     PrintLogo ${padd_size}
     PrintPiholeInformation ${padd_size}
@@ -1060,7 +1066,6 @@ NormalPADD() {
 
     # Sleep for 5 seconds, then clear the screen
     sleep 5
-    clear
   done
 }
 

--- a/padd.sh
+++ b/padd.sh
@@ -565,7 +565,7 @@ GetVersionInformation() {
 # terminfo clr_eol (clears to end of line
 ceol=$(tput el)
 
-CleanEcho() {
+CleanEcho  {
   tput el
   echo -e "$1"
 }
@@ -573,48 +573,48 @@ CleanEcho() {
 PrintLogo() {
   # Screen size checks
   if [ "$1" = "pico" ]; then
-    CleanEcho("p${padd_text} ${pico_status}")
+    CleanEcho "p${padd_text} ${pico_status}"
   elif [ "$1" = "nano" ]; then
-    CleanEcho("n${padd_text} ${mini_status_}")
+    CleanEcho "n${padd_text} ${mini_status_}"
   elif [ "$1" = "micro" ]; then
-    CleanEcho("µ${padd_text}     ${mini_status_}\\n")
+    CleanEcho "µ${padd_text}     ${mini_status_}\\n"
   elif [ "$1" = "mini" ]; then
-    CleanEcho("${padd_text}${dim_text}mini${reset_text}  ${mini_status_}\\n")
+    CleanEcho "${padd_text}${dim_text}mini${reset_text}  ${mini_status_}\\n"
   elif [ "$1" = "slim" ]; then
-    CleanEcho("${padd_text}${dim_text}slim${reset_text}   ${full_status_}\\n")
+    CleanEcho "${padd_text}${dim_text}slim${reset_text}   ${full_status_}\\n"
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    CleanEcho("${padd_logo_1}")
-    CleanEcho("${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}")
-    CleanEcho("${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}")
-    CleanEcho("")
+    CleanEcho "${padd_logo_1}"
+    CleanEcho "${padd_logo_2}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}"
+    CleanEcho "${padd_logo_3}PADD ${padd_version_heatmap}v${padd_version}${reset_text}${full_status_}${reset_text}"
+    CleanEcho ""
   # normal or not defined
   else
-    CleanEcho("${padd_logo_retro_1}")
-    CleanEcho("${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}")
-    CleanEcho("${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}")
+    CleanEcho "${padd_logo_retro_1}"
+    CleanEcho "${padd_logo_retro_2}   Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}, PADD ${padd_version_heatmap}v${padd_version}${reset_text}"
+    CleanEcho "${padd_logo_retro_3}   ${pihole_check_box} Core  ${ftl_check_box} FTL   ${mega_status}${reset_text}"
 
-    CleanEcho("")
+    CleanEcho ""
   fi
 }
 
 PrintNetworkInformation() {
   if [ "$1" = "pico" ]; then
-    CleanEcho("${bold_text}NETWORK ============${reset_text}")
-    CleanEcho(" Hst: ${pi_hostname}")
-    CleanEcho(" IP:  ${pi_ip_address}")
-    CleanEcho(" DHCP ${dhcp_check_box} IPv6 ${dhcp_ipv6_check_box}")
+    CleanEcho "${bold_text}NETWORK ============${reset_text}"
+    CleanEcho " Hst: ${pi_hostname}"
+    CleanEcho " IP:  ${pi_ip_address}"
+    CleanEcho " DHCP ${dhcp_check_box} IPv6 ${dhcp_ipv6_check_box}"
   elif [ "$1" = "nano" ]; then
-    CleanEcho("${bold_text}NETWORK ================${reset_text}")
-    CleanEcho(" Host: ${pi_hostname}")
-    CleanEcho(" IPv4: ${IPV4_ADDRESS}")
-    CleanEcho(" DHCP: ${dhcp_check_box}    IPv6: ${dhcp_ipv6_check_box}")
+    CleanEcho "${bold_text}NETWORK ================${reset_text}"
+    CleanEcho " Host: ${pi_hostname}"
+    CleanEcho " IPv4: ${IPV4_ADDRESS}"
+    CleanEcho " DHCP: ${dhcp_check_box}    IPv6: ${dhcp_ipv6_check_box}"
   elif [ "$1" = "micro" ]; then
-    CleanEcho("${bold_text}NETWORK ======================${reset_text}")
-    CleanEcho(" Host:    ${full_hostname}")
-    CleanEcho(" IPv4:    ${IPV4_ADDRESS}")
-    CleanEcho(" DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}")
+    CleanEcho "${bold_text}NETWORK ======================${reset_text}"
+    CleanEcho " Host:    ${full_hostname}"
+    CleanEcho " IPv4:    ${IPV4_ADDRESS}"
+    CleanEcho " DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
   elif [ "$1" = "mini" ]; then
-    CleanEcho("${bold_text}NETWORK ================================${reset_text}")
+    CleanEcho "${bold_text}NETWORK ================================${reset_text}"
     tput el
     printf " %-9s%-19s\\n" "Host:" "${full_hostname}"
     tput el
@@ -627,7 +627,7 @@ PrintNetworkInformation() {
       printf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    CleanEcho("${bold_text}NETWORK ====================================================${reset_text}")
+    CleanEcho "${bold_text}NETWORK ====================================================${reset_text}"
     tput el
     printf " %-10s%-19s %-10s%-19s\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
     tput el
@@ -642,18 +642,18 @@ PrintNetworkInformation() {
       printf "%s\\n" "${dhcp_info}"
     fi
   else
-    CleanEcho("${bold_text}NETWORK ========================================================================${reset_text}")
+    CleanEcho "${bold_text}NETWORK ========================================================================${reset_text}"
     tput el
     printf " %-10s%-19s\\n" "Hostname:" "${full_hostname}"
     tput el
     printf " %-10s%-19s %-10s%-29s\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
-    CleanEcho("DNS ============================================================================")
+    CleanEcho "DNS ============================================================================"
     tput el
     printf " %-10s%-39s\\n" "Servers:" "${dns_information}"
     tput el
     printf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
 
-    CleanEcho("DHCP ===========================================================================")
+    CleanEcho "DHCP ==========================================================================="
     tput el
     printf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
     tput el
@@ -666,17 +666,17 @@ PrintPiholeInformation() {
   if [ "$1" = "pico" ]; then
     :
   elif [ "$1" = "nano" ]; then
-    CleanEcho("${bold_text}PI-HOLE ================${reset_text}")
-    CleanEcho(" Up:  ${pihole_check_box}      FTL: ${ftl_check_box}")
+    CleanEcho "${bold_text}PI-HOLE ================${reset_text}"
+    CleanEcho " Up:  ${pihole_check_box}      FTL: ${ftl_check_box}"
   elif [ "$1" = "micro" ]; then
-    CleanEcho("${bold_text}PI-HOLE ======================${reset_text}")
-    CleanEcho(" Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}")
+    CleanEcho "${bold_text}PI-HOLE ======================${reset_text}"
+    CleanEcho " Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}"
   elif [ "$1" = "mini" ]; then
-    CleanEcho("${bold_text}PI-HOLE ================================${reset_text}")
+    CleanEcho "${bold_text}PI-HOLE ================================${reset_text}"
     tput el
     printf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    CleanEcho("${bold_text}PI-HOLE ====================================================${reset_text}")
+    CleanEcho "${bold_text}PI-HOLE ====================================================${reset_text}"
     tput el
     printf " %-10s${pihole_heatmap}%-19s${reset_text} %-10s${ftl_heatmap}%-19s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   else
@@ -687,19 +687,19 @@ PrintPiholeInformation() {
 PrintPiholeStats() {
   # are we on a tiny screen?
   if [ "$1" = "pico" ]; then
-    CleanEcho("${bold_text}PI-HOLE ============${reset_text}")
-    CleanEcho(" [${ads_blocked_bar}] ${ads_percentage_today}%")
-    CleanEcho(" ${ads_blocked_today} / ${dns_queries_today}")
+    CleanEcho "${bold_text}PI-HOLE ============${reset_text}"
+    CleanEcho " [${ads_blocked_bar}] ${ads_percentage_today}%"
+    CleanEcho " ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "nano" ]; then
-    CleanEcho(" Blk: [${ads_blocked_bar}] ${ads_percentage_today}%")
-    CleanEcho(" Blk: ${ads_blocked_today} / ${dns_queries_today}")
+    CleanEcho " Blk: [${ads_blocked_bar}] ${ads_percentage_today}%"
+    CleanEcho " Blk: ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "micro" ]; then
-    CleanEcho("${bold_text}STATS ========================${reset_text}")
-    CleanEcho(" Blckng:  ${domains_being_blocked} domains")
-    CleanEcho(" Piholed: [${ads_blocked_bar}] ${ads_percentage_today}%")
-    CleanEcho(" Piholed: ${ads_blocked_today} / ${dns_queries_today}")
+    CleanEcho "${bold_text}STATS ========================${reset_text}"
+    CleanEcho " Blckng:  ${domains_being_blocked} domains"
+    CleanEcho " Piholed: [${ads_blocked_bar}] ${ads_percentage_today}%"
+    CleanEcho " Piholed: ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "mini" ]; then
-    CleanEcho("${bold_text}STATS ==================================${reset_text}")
+    CleanEcho "${bold_text}STATS ==================================${reset_text}"
     tput el
     printf " %-9s%-29s\\n" "Blckng:" "${domains_being_blocked} domains"
     tput el
@@ -713,7 +713,7 @@ PrintPiholeStats() {
       printf " %-9s%-29s\\n" "Top Ad:" "${top_blocked}"
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    CleanEcho("${bold_text}STATS ======================================================${reset_text}")
+    CleanEcho "${bold_text}STATS ======================================================${reset_text}"
     tput el
     printf " %-10s%-49s\\n" "Blocking:" "${domains_being_blocked} domains"
     tput el
@@ -731,7 +731,7 @@ PrintPiholeStats() {
       printf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
     fi
   else
-    CleanEcho("${bold_text}STATS ==========================================================================${reset_text}")
+    CleanEcho "${bold_text}STATS ==========================================================================${reset_text}"
     tput el
     printf " %-10s%-19s %-10s[%-40s] %-5s\\n" "Blocking:" "${domains_being_blocked} domains" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
     tput el
@@ -744,7 +744,7 @@ PrintPiholeStats() {
     printf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
     tput el
     printf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
-    CleanEcho("FTL ============================================================================")
+    CleanEcho "FTL ============================================================================"
     tput el
     printf " %-10s%-9s %-10s%-9s %-10s%-9s\\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
     tput el
@@ -754,26 +754,26 @@ PrintPiholeStats() {
 
 PrintSystemInformation() {
   if [ "$1" = "pico" ]; then
-    CleanEcho("${bold_text}CPU ================${reset_text}")
+    CleanEcho "${bold_text}CPU ================${reset_text}"
     echo -ne "${ceol} [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
   elif [ "$1" = "nano" ]; then
-    CleanEcho("${ceol}${bold_text}SYSTEM =================${reset_text}")
-    CleanEcho(" Up:  ${system_uptime}")
+    CleanEcho "${ceol}${bold_text}SYSTEM =================${reset_text}"
+    CleanEcho " Up:  ${system_uptime}"
     echo -ne  "${ceol} CPU: [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
   elif [ "$1" = "micro" ]; then
-    CleanEcho("${bold_text}SYSTEM =======================${reset_text}")
-    CleanEcho(" Uptime:  ${system_uptime}")
-    CleanEcho(" Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%")
+    CleanEcho "${bold_text}SYSTEM =======================${reset_text}"
+    CleanEcho " Uptime:  ${system_uptime}"
+    CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
     echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   elif [ "$1" = "mini" ]; then
-    CleanEcho("${bold_text}SYSTEM =================================${reset_text}")
+    CleanEcho "${bold_text}SYSTEM =================================${reset_text}"
     tput el
     printf " %-9s%-29s\\n" "Uptime:" "${system_uptime}"
-    CleanEcho(" Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%")
+    CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
     echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   # else we're not
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
-    CleanEcho("${bold_text}SYSTEM =====================================================${reset_text}")
+    CleanEcho "${bold_text}SYSTEM =====================================================${reset_text}"
     # Uptime
     tput el
     printf " %-10s%-39s\\n" "Uptime:" "${system_uptime}"

--- a/padd.sh
+++ b/padd.sh
@@ -570,9 +570,9 @@ CleanEcho() {
   echo -e $1 "${ceol}"
 }
 
-# wrapper - printf with a clear eol first
+# wrapper - printf
 CleanPrintf() {
-#  tput el
+# tput el
   printf "$@"
 }
 
@@ -590,7 +590,7 @@ PrintLogo() {
     CleanEcho ""
   elif [ "$1" = "slim" ]; then
     CleanEcho "${padd_text}${dim_text}slim${reset_text}   ${full_status_}"
-    CleanEcho ""\
+    CleanEcho ""
   # For the next two, use printf to make sure spaces aren't collapsed
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanPrintf "${padd_logo_1}\e[0K\\n"
@@ -1082,7 +1082,7 @@ NormalPADD() {
     GetSummaryInformation ${padd_size}
     GetSystemInformation ${padd_size}
 
-    # Sleep for 5 seconds, then clear the screen
+    # Sleep for 5 seconds
     sleep 5
   done
 }

--- a/padd.sh
+++ b/padd.sh
@@ -569,6 +569,10 @@ CleanEcho() {
   tput el
   echo -e $1
 }
+CleanPrintf() {
+  tput el
+  printf "$@"
+}
 
 PrintLogo() {
   # Screen size checks
@@ -615,49 +619,34 @@ PrintNetworkInformation() {
     CleanEcho " DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}NETWORK ================================${reset_text}"
-    tput el
-    printf " %-9s%-19s\\n" "Host:" "${full_hostname}"
-    tput el
-    printf " %-9s%-19s\\n" "IPv4:" "${IPV4_ADDRESS}"
-    tput el
-    printf " %-9s%-10s\\n" "DNS:" "${dns_information}"
+    CleanPrintf " %-9s%-19s\\n" "Host:" "${full_hostname}"
+    CleanPrintf " %-9s%-19s\\n" "IPv4:" "${IPV4_ADDRESS}"
+    CleanPrintf " %-9s%-10s\\n" "DNS:" "${dns_information}"
 
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
-      tput el
-      printf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
+      CleanPrintf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}NETWORK ====================================================${reset_text}"
-    tput el
-    printf " %-10s%-19s %-10s%-19s\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
-    tput el
-    printf " %-10s%-19s\\n" "IPv6:" "${IPV6_ADDRESS}"
-    tput el
-    printf " %-10s%-19s %-10s%-19s\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
+    CleanPrintf " %-10s%-19s %-10s%-19s\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
+    CleanPrintf " %-10s%-19s\\n" "IPv6:" "${IPV6_ADDRESS}"
+    CleanPrintf " %-10s%-19s %-10s%-19s\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
-      tput el
-      printf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-19s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
-      tput el
-      printf "%s\\n" "${dhcp_info}"
+      CleanPrintf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-19s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
+      CleanPrintf "%s\\n" "${dhcp_info}"
     fi
   else
     CleanEcho "${bold_text}NETWORK ========================================================================${reset_text}"
-    tput el
-    printf " %-10s%-19s\\n" "Hostname:" "${full_hostname}"
-    tput el
-    printf " %-10s%-19s %-10s%-29s\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
+    CleanPrintf " %-10s%-19s\\n" "Hostname:" "${full_hostname}"
+    CleanPrintf " %-10s%-19s %-10s%-29s\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
     CleanEcho "DNS ============================================================================"
-    tput el
-    printf " %-10s%-39s\\n" "Servers:" "${dns_information}"
-    tput el
-    printf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
+    CleanPrintf " %-10s%-39s\\n" "Servers:" "${dns_information}"
+    CleanPrintf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
 
     CleanEcho "DHCP ==========================================================================="
-    tput el
-    printf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
-    tput el
-    printf "%s\\n" "${dhcp_info}"
+    CleanPrintf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
+    CleanPrintf "%s\\n" "${dhcp_info}"
   fi
 }
 
@@ -673,12 +662,10 @@ PrintPiholeInformation() {
     CleanEcho " Status:  ${pihole_check_box}      FTL:  ${ftl_check_box}"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}PI-HOLE ================================${reset_text}"
-    tput el
-    printf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
+    CleanPrintf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}PI-HOLE ====================================================${reset_text}"
-    tput el
-    printf " %-10s${pihole_heatmap}%-19s${reset_text} %-10s${ftl_heatmap}%-19s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
+    CleanPrintf " %-10s${pihole_heatmap}%-19s${reset_text} %-10s${ftl_heatmap}%-19s${reset_text}\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
   else
     return
   fi
@@ -700,55 +687,35 @@ PrintPiholeStats() {
     CleanEcho " Piholed: ${ads_blocked_today} / ${dns_queries_today}"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}STATS ==================================${reset_text}"
-    tput el
-    printf " %-9s%-29s\\n" "Blckng:" "${domains_being_blocked} domains"
-    tput el
-    printf " %-9s[%-20s] %-5s\\n" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
-    tput el
-    printf " %-9s%-29s\\n" "Piholed:" "${ads_blocked_today} out of ${dns_queries_today}"
-    tput el
-    printf " %-9s%-29s\\n" "Latest:" "${latest_blocked}"
+    CleanPrintf " %-9s%-29s\\n" "Blckng:" "${domains_being_blocked} domains"
+    CleanPrintf " %-9s[%-20s] %-5s\\n" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    CleanPrintf " %-9s%-29s\\n" "Piholed:" "${ads_blocked_today} out of ${dns_queries_today}"
+    CleanPrintf " %-9s%-29s\\n" "Latest:" "${latest_blocked}"
     if [[ "${DHCP_ACTIVE}" != "true" ]]; then
-      tput el
-      printf " %-9s%-29s\\n" "Top Ad:" "${top_blocked}"
+      CleanPrintf " %-9s%-29s\\n" "Top Ad:" "${top_blocked}"
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}STATS ======================================================${reset_text}"
-    tput el
-    printf " %-10s%-49s\\n" "Blocking:" "${domains_being_blocked} domains"
-    tput el
-    printf " %-10s[%-40s] %-5s\\n" "Pi-holed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
-    tput el
-    printf " %-10s%-49s\\n" "Pi-holed:" "${ads_blocked_today} out of ${dns_queries_today} queries"
-    tput el
-    printf " %-10s%-39s\\n" "Latest:" "${latest_blocked}"
-    tput el
-    printf " %-10s%-39s\\n" "Top Ad:" "${top_blocked}"
+    CleanPrintf " %-10s%-49s\\n" "Blocking:" "${domains_being_blocked} domains"
+    CleanPrintf " %-10s[%-40s] %-5s\\n" "Pi-holed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    CleanPrintf " %-10s%-49s\\n" "Pi-holed:" "${ads_blocked_today} out of ${dns_queries_today} queries"
+    CleanPrintf " %-10s%-39s\\n" "Latest:" "${latest_blocked}"
+    CleanPrintf " %-10s%-39s\\n" "Top Ad:" "${top_blocked}"
     if [[ "${DHCP_ACTIVE}" != "true" ]]; then
-      tput el
-      printf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
-      tput el
-      printf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
+      CleanPrintf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
+      CleanPrintf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
     fi
   else
     CleanEcho "${bold_text}STATS ==========================================================================${reset_text}"
-    tput el
-    printf " %-10s%-19s %-10s[%-40s] %-5s\\n" "Blocking:" "${domains_being_blocked} domains" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
-    tput el
-    printf " %-10s%-30s%-29s\\n" "Clients:" "${clients}" " ${ads_blocked_today} out of ${dns_queries_today} queries"
-    tput el
-    printf " %-10s%-39s\\n" "Latest:" "${latest_blocked}"
-    tput el
-    printf " %-10s%-39s\\n" "Top Ad:" "${top_blocked}"
-    tput el
-    printf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
-    tput el
-    printf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
+    CleanPrintf " %-10s%-19s %-10s[%-40s] %-5s\\n" "Blocking:" "${domains_being_blocked} domains" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    CleanPrintf " %-10s%-30s%-29s\\n" "Clients:" "${clients}" " ${ads_blocked_today} out of ${dns_queries_today} queries"
+    CleanPrintf " %-10s%-39s\\n" "Latest:" "${latest_blocked}"
+    CleanPrintf " %-10s%-39s\\n" "Top Ad:" "${top_blocked}"
+    CleanPrintf " %-10s%-39s\\n" "Top Dmn:" "${top_domain}"
+    CleanPrintf " %-10s%-39s\\n" "Top Clnt:" "${top_client}"
     CleanEcho "FTL ============================================================================"
-    tput el
-    printf " %-10s%-9s %-10s%-9s %-10s%-9s\\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
-    tput el
-    printf " %-10s%-69s\\n" "DNSCache:" "${cache_inserts} insertions, ${cache_deletes} deletions, ${cache_size} total entries"
+    CleanPrintf " %-10s%-9s %-10s%-9s %-10s%-9s\\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
+    CleanPrintf " %-10s%-69s\\n" "DNSCache:" "${cache_inserts} insertions, ${cache_deletes} deletions, ${cache_size} total entries"
   fi
 }
 
@@ -767,35 +734,28 @@ PrintSystemInformation() {
     echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}SYSTEM =================================${reset_text}"
-    tput el
-    printf " %-9s%-29s\\n" "Uptime:" "${system_uptime}"
+    CleanPrintf " %-9s%-29s\\n" "Uptime:" "${system_uptime}"
     CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
     echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   # else we're not
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}SYSTEM =====================================================${reset_text}"
     # Uptime
-    tput el
-    printf " %-10s%-39s\\n" "Uptime:" "${system_uptime}"
+    CleanPrintf " %-10s%-39s\\n" "Uptime:" "${system_uptime}"
 
     # Temp and Loads
-    tput el
-    printf " %-10s${temp_heatmap}%-20s${reset_text}" "CPU Temp:" "${temperature}"
-    tput el
-    printf " %-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}\\n" "CPU Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}"
+    CleanPrintf " %-10s${temp_heatmap}%-20s${reset_text}" "CPU Temp:" "${temperature}"
+    CleanPrintf " %-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}\\n" "CPU Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}"
 
     # Memory and CPU bar
-    tput el
-    printf " %-10s[${memory_heatmap}%-10s${reset_text}] %-6s %-10s[${cpu_load_1_heatmap}%-10s${reset_text}] %-5s" "Memory:" "${memory_bar}" "${memory_percent}%" "CPU Load:" "${cpu_bar}" "${cpu_percent}%"
+    CleanPrintf " %-10s[${memory_heatmap}%-10s${reset_text}] %-6s %-10s[${cpu_load_1_heatmap}%-10s${reset_text}] %-5s" "Memory:" "${memory_bar}" "${memory_percent}%" "CPU Load:" "${cpu_bar}" "${cpu_percent}%"
   else
     echo "${ceol}${bold_text}SYSTEM =========================================================================${reset_text}"
     # Uptime and memory
-    tput el
-    printf " %-10s%-39s %-10s[${memory_heatmap}%-10s${reset_text}] %-6s\\n" "Uptime:" "${system_uptime}" "Memory:" "${memory_bar}" "${memory_percent}%"
+    CleanPrintf " %-10s%-39s %-10s[${memory_heatmap}%-10s${reset_text}] %-6s\\n" "Uptime:" "${system_uptime}" "Memory:" "${memory_bar}" "${memory_percent}%"
 
     # CPU temp, load, percentage
-    tput el
-    printf " %-10s${temp_heatmap}%-10s${reset_text} %-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-7s${reset_text} %-10s[${memory_heatmap}%-10s${reset_text}] %-6s" "CPU Temp:" "${temperature}" "CPU Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}" "CPU Load:" "${cpu_bar}" "${cpu_percent}%"
+    CleanPrintf " %-10s${temp_heatmap}%-10s${reset_text} %-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-7s${reset_text} %-10s[${memory_heatmap}%-10s${reset_text}] %-6s" "CPU Temp:" "${temperature}" "CPU Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}" "CPU Load:" "${cpu_bar}" "${cpu_percent}%"
   fi
 }
 
@@ -1102,9 +1062,6 @@ NormalPADD() {
     PrintPiholeStats ${padd_size}
     PrintNetworkInformation ${padd_size}
     PrintSystemInformation ${padd_size}
-    
-    # Clear up any artifacts if we shrank the screen by clearing from cursor to end of screen
-    tput ed
 
     pico_status=${pico_status_ok}
     mini_status_=${mini_status_ok}

--- a/padd.sh
+++ b/padd.sh
@@ -610,45 +610,48 @@ PrintNetworkInformation() {
     echo -e "${ceol} DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
   elif [ "$1" = "mini" ]; then
     echo "${bold_text}NETWORK ================================${reset_text}"
-    ceol
+    tput el
     printf " %-9s%-19s\\n" "Host:" "${full_hostname}"
-    ceol
+    tput el
     printf " %-9s%-19s\\n" "IPv4:" "${IPV4_ADDRESS}"
-    ceol
+    tput el
     printf " %-9s%-10s\\n" "DNS:" "${dns_information}"
 
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
+      tput el
       printf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
     fi
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     echo "${bold_text}NETWORK ====================================================${reset_text}"
-    ceol
+    tput el
     printf " %-10s%-19s %-10s%-19s\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
-    ceol
+    tput el
     printf " %-10s%-19s\\n" "IPv6:" "${IPV6_ADDRESS}"
-    ceol
+    tput el
     printf " %-10s%-19s %-10s%-19s\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
+      tput el
       printf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-19s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
+      tput el
       printf "%s\\n" "${dhcp_info}"
     fi
   else
     echo "${bold_text}NETWORK ========================================================================${reset_text}"
-    ceol
+    tput el
     printf " %-10s%-19s\\n" "Hostname:" "${full_hostname}"
-    ceol
+    tput el
     printf " %-10s%-19s %-10s%-29s\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
     echo "DNS ============================================================================"
-    ceol
+    tput el
     printf " %-10s%-39s\\n" "Servers:" "${dns_information}"
-    ceol
+    tput el
     printf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"
 
     echo "DHCP ==========================================================================="
-    ceol
+    tput el
     printf " %-10s${dhcp_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}\\n" "DHCP:" "${dhcp_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
-    ceol
+    tput el
     printf "%s\\n" "${dhcp_info}"
   fi
 }

--- a/padd.sh
+++ b/padd.sh
@@ -644,7 +644,7 @@ PrintNetworkInformation() {
   else
     CleanEcho "${bold_text}NETWORK ========================================================================${reset_text}"
     CleanPrintf " %-10s%-19s\e[0K\\n" "Hostname:" "${full_hostname}"
-    CleanPrintf " %-10s%-19s %-10s%-29\e[0Ks\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
+    CleanPrintf " %-10s%-19s %-10s%-29s\e[0K\\n" "IPv4 Adr:" "${IPV4_ADDRESS}" "IPv6 Adr:" "${IPV6_ADDRESS}"
     CleanEcho "DNS ============================================================================"
     CleanPrintf " %-10s%-39s\e[0K\\n" "Servers:" "${dns_information}"
     CleanPrintf " %-10s${dnssec_heatmap}%-19s${reset_text} %-20s${conditional_forwarding_heatmap}%-9s${reset_text}\e[0K\\n" "DNSSEC:" "${dnssec_status}" "Conditional Fwding:" "${conditional_forwarding_status}"

--- a/padd.sh
+++ b/padd.sh
@@ -1102,6 +1102,9 @@ NormalPADD() {
     PrintPiholeStats ${padd_size}
     PrintNetworkInformation ${padd_size}
     PrintSystemInformation ${padd_size}
+    
+    # Clear up any artifacts if we shrank the screen by clearing from cursor to end of screen
+    tput ed
 
     pico_status=${pico_status_ok}
     mini_status_=${mini_status_ok}

--- a/padd.sh
+++ b/padd.sh
@@ -1062,6 +1062,9 @@ NormalPADD() {
     PrintPiholeStats ${padd_size}
     PrintNetworkInformation ${padd_size}
     PrintSystemInformation ${padd_size}
+    
+    # clear to end of screen
+    tput ed
 
     pico_status=${pico_status_ok}
     mini_status_=${mini_status_ok}

--- a/padd.sh
+++ b/padd.sh
@@ -731,12 +731,12 @@ PrintSystemInformation() {
     CleanEcho "${bold_text}SYSTEM =======================${reset_text}"
     CleanEcho " Uptime:  ${system_uptime}"
     CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
-    echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
+    echo -ne "${ceol}Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}SYSTEM =================================${reset_text}"
     CleanPrintf " %-9s%-29s\\n" "Uptime:" "${system_uptime}"
     CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
-    echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
+    echo -ne "${ceol}Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   # else we're not
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}SYSTEM =====================================================${reset_text}"
@@ -750,7 +750,7 @@ PrintSystemInformation() {
     # Memory and CPU bar
     CleanPrintf " %-10s[${memory_heatmap}%-10s${reset_text}] %-6s %-10s[${cpu_load_1_heatmap}%-10s${reset_text}] %-5s" "Memory:" "${memory_bar}" "${memory_percent}%" "CPU Load:" "${cpu_bar}" "${cpu_percent}%"
   else
-    echo "${ceol}${bold_text}SYSTEM =========================================================================${reset_text}"
+    CleanEcho "${bold_text}SYSTEM =========================================================================${reset_text}"
     # Uptime and memory
     CleanPrintf " %-10s%-39s %-10s[${memory_heatmap}%-10s${reset_text}] %-6s\\n" "Uptime:" "${system_uptime}" "Memory:" "${memory_bar}" "${memory_percent}%"
 

--- a/padd.sh
+++ b/padd.sh
@@ -562,13 +562,16 @@ GetVersionInformation() {
 
 ############################################# PRINTERS #############################################
 
-# terminfo clr_eol (clears to end of line
+# terminfo clr_eol (clears to end of line to erase artifacts after resizing smaller)
 ceol=$(tput el)
 
+# wrapper - echoe with a clear eol first
 CleanEcho() {
   tput el
   echo -e $1
 }
+
+# wrapper - printf with a clear eol first
 CleanPrintf() {
   tput el
   printf "$@"


### PR DESCRIPTION
The previous PADD display routine would 1) get info, 2) print the dashboard 3) wait 5 seconds 4) clear

This was causing issues, particularly on slower displays, where there was a perceptble black "flash" between the terminal being cleared and the dashboard being repopulated. 

I tried moving the clear command to just prior to the repopulation of the dashboard text, which helped a bit but the flash was still perceptible.

In order to solve the issue, instead of clearing the whole terminal and then rewriting all the lines, I move the cursor to the topleft of the console just prior to printing (`tput cup 0 0`) and overwrite each line. When I rewrite, I add a "clear to end of line" escape character that blanks out anything after the written text - this takes care of any artifacts after you shrink the screen, since a simple repaint would leave anything longer than the newline present. To do this cleanly and not bloat the code, I've added wrapper functions for echo (CleanEcho= `echo -e "text" "$(tput el)`) and printf (CleanPrintf), writing the clear-line-from-here escape character `"\e[0K"` prior to any newline in the printf calls. I also add a `tput ed` call after printing the rest of the output to clear any remaining text below the last line, which cleans up artifacts after resizing to a smaller format.

I recognize that the CleanPrintf wrapper isn't necessary in the final form, but it maintains consistency with CleanEcho so I kept it.

This update changes printing behavior only and it's friendly to resizing (you can resize to any size/format you want and it should still display just fine within 10 seconds aka 2 refresh cycles).

This pull request was a great exercise in learning the finer points of bash terminal control. Please let me know if there are any comments or changes, or if you encounter issues in your OS!

This fixes issue #69 