### PR TITLE
Fix PADDmini and PADDmicro label display

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -567,7 +567,7 @@ ceol=$(tput el)
 
 # wrapper - echo with a clear eol afterwards to wipe any artifacts remaining from last print
 CleanEcho() {
-  echo -e "${ceol}$1"
+  echo -e $1 "${ceol}"
 }
 
 # wrapper - printf
@@ -737,12 +737,12 @@ PrintSystemInformation() {
     CleanEcho "${bold_text}SYSTEM =======================${reset_text}"
     CleanEcho " Uptime:  ${system_uptime}"
     CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
-    echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
+    echo -ne "${ceol}Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}SYSTEM =================================${reset_text}"
     CleanPrintf " %-9s%-29s\e[0K\\n" "Uptime:" "${system_uptime}"
     CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
-    echo -ne "${ceol} Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
+    echo -ne "${ceol}Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   # else we're not
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}SYSTEM =====================================================${reset_text}"

--- a/padd.sh
+++ b/padd.sh
@@ -740,7 +740,7 @@ PrintSystemInformation() {
     echo -ne "${ceol}Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}SYSTEM =================================${reset_text}"
-    CleanPrintf " %-9s%-29s\\n" "Uptime:" "${system_uptime}"
+    CleanPrintf " %-9s%-29s\e[0K\\n" "Uptime:" "${system_uptime}"
     CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
     echo -ne "${ceol}Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
   # else we're not


### PR DESCRIPTION
Fixes [newly introduced](https://github.com/jpmck/PADD/commit/20a0881d7c61a5c2227cf65f52b1e656b1721478#diff-f0d2b00f20028b2c7f9febd84b9659afR746) indent and spacing issues in PADDmini (Load and Memory) and PADDmicro (Memory) label displays.

![before-after](https://user-images.githubusercontent.com/1605754/75684397-57539c80-5c5e-11ea-8621-f83bcc0a6952.jpg)
