### PR TITLE
fix version check

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -490,7 +490,7 @@ GetVersionInformation() {
     fi
 
     # PADD version information...
-    padd_version_latest=$(curl -sI https://github.com/jpmck/PADD/releases/latest | grep -i '^Location:' | awk -F '/' '{print $NF}' | tr -d '\r\n[:alpha:]')
+    padd_version_latest=$(curl -sI https://github.com/jpmck/PADD/releases/latest | awk -F / 'tolower($0) ~ /^location:/ {print $NF; exit}' | tr -d '\r\n[:alpha:]')
 
     # is PADD up-to-date?
     if [[ "${padd_version}" != "${padd_version_latest}" ]]; then

--- a/padd.sh
+++ b/padd.sh
@@ -490,7 +490,7 @@ GetVersionInformation() {
     fi
 
     # PADD version information...
-    padd_version_latest=$(curl -sI https://github.com/jpmck/PADD/releases/latest | grep -i 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n[:alpha:]')
+    padd_version_latest=$(curl -sI https://github.com/jpmck/PADD/releases/latest | grep -i '^Location:' | awk -F '/' '{print $NF}' | tr -d '\r\n[:alpha:]')
 
     # is PADD up-to-date?
     if [[ "${padd_version}" != "${padd_version_latest}" ]]; then

--- a/padd.sh
+++ b/padd.sh
@@ -490,7 +490,7 @@ GetVersionInformation() {
     fi
 
     # PADD version information...
-    padd_version_latest=$(curl -sI https://github.com/jpmck/PADD/releases/latest | grep 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n[:alpha:]')
+    padd_version_latest=$(curl -sI https://github.com/jpmck/PADD/releases/latest | grep -i 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n[:alpha:]')
 
     # is PADD up-to-date?
     if [[ "${padd_version}" != "${padd_version_latest}" ]]; then


### PR DESCRIPTION
case insensitive http header parsing. Github now returns all lowercase location header:
reference: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

```
$ curl -sI https://github.com/jpmck/PADD/releases/latest
HTTP/1.1 302 Found
date: Sun, 22 Mar 2020 11:20:35 GMT
content-type: text/html; charset=utf-8
server: GitHub.com
status: 302 Found
vary: X-PJAX, Accept-Encoding, Accept, X-Requested-With
location: https://github.com/jpmck/PADD/releases/tag/v3.1
[...]
```